### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/branch-control.yml
+++ b/.github/workflows/branch-control.yml
@@ -1,5 +1,8 @@
 name: Branch Compliance Control
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main, QA]


### PR DESCRIPTION
Potential fix for [https://github.com/Ktols/PodoFlow/security/code-scanning/1](https://github.com/Ktols/PodoFlow/security/code-scanning/1)

In general, the problem is fixed by adding an explicit `permissions` block to the workflow or to the specific job, granting only the minimal permissions required. Since this job only reads branch names from the GitHub-provided context and does not interact with the API or repository contents, it does not need the `GITHUB_TOKEN` at all. The safest least-privilege setting here is `permissions: { contents: read }` at the workflow level, or even `permissions: { contents: read }` or `permissions: { contents: read }` at the job level; however, GitHub supports `permissions: { contents: read }` or `permissions: {} | none`. Because the job does not use the token, we can explicitly set `permissions: { contents: read }` as a minimal standard baseline or `permissions: { contents: read }` equivalent to read-only defaults. To align with the background recommendation and be clear, we will add a root-level `permissions` block, applying to all jobs.

Concretely, in `.github/workflows/branch-control.yml`, we will insert a `permissions:` section directly under the `name:` declaration (line 1) and before the `on:` block (line 3). We will specify only read access to repository contents, which is sufficient if any future step uses checkout or similar, while still being minimal. No imports or additional methods are needed, as this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
